### PR TITLE
Add "limits" snippets

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -969,10 +969,15 @@
 		"prefix": "limsup",
 		"body": ["\\limsup "]
 	},
+	"LaTeX - limits": {
+		"scope": "",
+		"prefix": "limits",
+		"body": ["\\limits_{$1}^{$2} $0"]
+	},
 	"LaTeX - lim": {
 		"scope": "",
 		"prefix": "lim",
-		"body": ["\\lim_{${1:x} \\to ${2:\\infty}} $0"]
+		"body": ["\\lim \\limits_{${1:x} \\to ${2:\\infty}} $0"]
 	},
 
 
@@ -1443,7 +1448,7 @@
 	"LaTeX - sum": {
 		"scope": "",
 		"prefix": "sum",
-		"body": ["\\sum_{$1}^{$2}$0"]
+		"body": ["\\sum \\limits_{$1}^{$2}$0"]
 	},
 	"LaTeX - prod": {
 		"scope": "",


### PR DESCRIPTION
添加了一个“limits”的片段，并修改"sum"和"lim"的片段，为这两个片段添加了“limit”，使“sum“和”lim“的显示效果更符合数学公式书写特点。
Added a snippet of "limits" and modified the snippets of "sum" and "lim", adding "limit" to these two snippets, so that the display effect of "sum" and "lim" is more in line with the writing characteristics of mathematical formulas.